### PR TITLE
Making resize cursors appear when hovering the resize areas

### DIFF
--- a/src/css/window.css
+++ b/src/css/window.css
@@ -154,10 +154,12 @@
 
 .wl {
 	left: -5px;
+	cursor: w-resize;
 }
 
 .wr {
 	right: -5px;
+	cursor: e-resize;
 }
 
 .ht, .hb {
@@ -169,10 +171,12 @@
 
 .ht {
 	top: -5px;
+	cursor: n-resize;
 }
 
 .hb {
 	bottom: -5px;
+	cursor: s-resize;
 }
 
 .whlt, .whrt, .whlb, .whrb {
@@ -184,21 +188,25 @@
 .whlt {
 	top: -5px;
 	left: -5px;
+	cursor: nw-resize;
 }
 
 .whrt {
 	top: -5px;
 	right: -5px;
+	cursor: ne-resize;
 }
 
 .whrb {
 	bottom: -5px;
 	right: -5px;
+	cursor: se-resize;
 }
 
 .whlb {
 	bottom: -5px;
 	left: -5px;
+	cursor: sw-resize;
 }
 
 /* 

--- a/src/js/windows.js
+++ b/src/js/windows.js
@@ -1317,42 +1317,42 @@ class Window {
 			var wl = document.createElement("div");
 			wl.classList.add("wl");
 			wl.id = "wl"+Window.#win_id;
-			wl.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${wl.id}`, `#${win.id}`, (e, target, info) => {document.body.style.cursor="e-resize"}, moveUpAndClean, undefined, dragResizeWL, (e, target, info) => {document.body.style.cursor=null}, undefined, undefined, true, false)});
+			wl.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${wl.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="e-resize"}*/, moveUpAndClean, undefined, dragResizeWL, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, true, false)});
 
 			var wr = document.createElement("div");
 			wr.classList.add("wr");
 			wr.id = "wr"+Window.#win_id;
-			wr.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${wr.id}`, `#${win.id}`, (e, target, info) => {document.body.style.cursor="w-resize"}, moveUpAndClean,  undefined, dragResizeWR, (e, target, info) => {document.body.style.cursor=null}, undefined, undefined, false, false)});
+			wr.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${wr.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="w-resize"}*/, moveUpAndClean,  undefined, dragResizeWR, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, false, false)});
 
 			var ht = document.createElement("div");
 			ht.classList.add("ht");
 			ht.id = "ht"+Window.#win_id;
-			ht.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${ht.id}`, `#${win.id}`, (e, target, info) => {document.body.style.cursor="s-resize"}, moveUpAndClean, undefined, dragResizeHT, (e, target, info) => {document.body.style.cursor=null}, undefined, undefined, false, true)});
+			ht.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${ht.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="s-resize"}*/, moveUpAndClean, undefined, dragResizeHT, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, false, true)});
 
 			var hb = document.createElement("div");
 			hb.classList.add("hb");
 			hb.id = "hb"+Window.#win_id;
-			hb.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${hb.id}`, `#${win.id}`, (e, target, info) => {document.body.style.cursor="n-resize"}, moveUpAndClean,  undefined, dragResizeHB, (e, target, info) => {document.body.style.cursor=null}, undefined, undefined, false, false)});
+			hb.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${hb.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="n-resize"}*/, moveUpAndClean,  undefined, dragResizeHB, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, false, false)});
 
 			var whlt = document.createElement("div");
 			whlt.classList.add("whlt");
 			whlt.id = "whlt"+Window.#win_id;
-			whlt.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whlt.id}`, `#${win.id}`, (e, target, info) => {document.body.style.cursor="se-resize"}, moveUpAndClean, undefined, dragResizeWHLT, (e, target, info) => {document.body.style.cursor=null}, undefined, undefined, true, true)});
+			whlt.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whlt.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="se-resize"}*/, moveUpAndClean, undefined, dragResizeWHLT, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, true, true)});
 
 			var whrt = document.createElement("div");
 			whrt.classList.add("whrt");
 			whrt.id = "whrt"+Window.#win_id;
-			whrt.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whrt.id}`, `#${win.id}`, (e, target, info) => {document.body.style.cursor="sw-resize"}, moveUpAndClean, undefined, dragResizeWHRT, (e, target, info) => {document.body.style.cursor=null}, undefined, undefined, false, true)});
+			whrt.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whrt.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="sw-resize"}*/, moveUpAndClean, undefined, dragResizeWHRT, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, false, true)});
 
 			var whlb = document.createElement("div");
 			whlb.classList.add("whlb");
 			whlb.id = "whlb"+Window.#win_id;
-			whlb.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whlb.id}`, `#${win.id}`, (e, target, info) => {document.body.style.cursor="nw-resize"}, moveUpAndClean, undefined, dragResizeWHLB, (e, target, info) => {document.body.style.cursor=null}, undefined, undefined, true, false)});
+			whlb.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whlb.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="nw-resize"}*/, moveUpAndClean, undefined, dragResizeWHLB, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, true, false)});
 
 			var whrb = document.createElement("div");
 			whrb.classList.add("whrb");
 			whrb.id = "whrb"+Window.#win_id;
-			whrb.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whrb.id}`, `#${win.id}`, (e, target, info) => {document.body.style.cursor="ne-resize"}, moveUpAndClean, undefined, dragResizeWHRB, (e, target, info) => {document.body.style.cursor=null}, undefined, undefined, false, false)});
+			whrb.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whrb.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="ne-resize"}*/, moveUpAndClean, undefined, dragResizeWHRB, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, false, false)});
 		}
 
 		window.addEventListener("mouseup", e => {DragAndDrop.drop(e, `#${win.id}`)});

--- a/src/js/windows.js
+++ b/src/js/windows.js
@@ -1317,42 +1317,42 @@ class Window {
 			var wl = document.createElement("div");
 			wl.classList.add("wl");
 			wl.id = "wl"+Window.#win_id;
-			wl.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${wl.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="e-resize"}*/, moveUpAndClean, undefined, dragResizeWL, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, true, false)});
+			wl.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${wl.id}`, `#${win.id}`, undefined, moveUpAndClean, undefined, dragResizeWL, undefined, undefined, undefined, true, false)});
 
 			var wr = document.createElement("div");
 			wr.classList.add("wr");
 			wr.id = "wr"+Window.#win_id;
-			wr.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${wr.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="w-resize"}*/, moveUpAndClean,  undefined, dragResizeWR, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, false, false)});
+			wr.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${wr.id}`, `#${win.id}`, undefined, moveUpAndClean,  undefined, dragResizeWR, undefined, undefined, undefined, false, false)});
 
 			var ht = document.createElement("div");
 			ht.classList.add("ht");
 			ht.id = "ht"+Window.#win_id;
-			ht.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${ht.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="s-resize"}*/, moveUpAndClean, undefined, dragResizeHT, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, false, true)});
+			ht.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${ht.id}`, `#${win.id}`, undefined, moveUpAndClean, undefined, dragResizeHT, undefined, undefined, undefined, false, true)});
 
 			var hb = document.createElement("div");
 			hb.classList.add("hb");
 			hb.id = "hb"+Window.#win_id;
-			hb.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${hb.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="n-resize"}*/, moveUpAndClean,  undefined, dragResizeHB, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, false, false)});
+			hb.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${hb.id}`, `#${win.id}`, undefined, moveUpAndClean,  undefined, dragResizeHB, undefined, undefined, undefined, false, false)});
 
 			var whlt = document.createElement("div");
 			whlt.classList.add("whlt");
 			whlt.id = "whlt"+Window.#win_id;
-			whlt.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whlt.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="se-resize"}*/, moveUpAndClean, undefined, dragResizeWHLT, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, true, true)});
+			whlt.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whlt.id}`, `#${win.id}`, undefined, moveUpAndClean, undefined, dragResizeWHLT, undefined, undefined, undefined, true, true)});
 
 			var whrt = document.createElement("div");
 			whrt.classList.add("whrt");
 			whrt.id = "whrt"+Window.#win_id;
-			whrt.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whrt.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="sw-resize"}*/, moveUpAndClean, undefined, dragResizeWHRT, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, false, true)});
+			whrt.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whrt.id}`, `#${win.id}`, undefined, moveUpAndClean, undefined, dragResizeWHRT, undefined, undefined, undefined, false, true)});
 
 			var whlb = document.createElement("div");
 			whlb.classList.add("whlb");
 			whlb.id = "whlb"+Window.#win_id;
-			whlb.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whlb.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="nw-resize"}*/, moveUpAndClean, undefined, dragResizeWHLB, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, true, false)});
+			whlb.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whlb.id}`, `#${win.id}`, undefined, moveUpAndClean, undefined, dragResizeWHLB, undefined, undefined, undefined, true, false)});
 
 			var whrb = document.createElement("div");
 			whrb.classList.add("whrb");
 			whrb.id = "whrb"+Window.#win_id;
-			whrb.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whrb.id}`, `#${win.id}`, undefined /*(e, target, info) => {document.body.style.cursor="ne-resize"}*/, moveUpAndClean, undefined, dragResizeWHRB, undefined /*(e, target, info) => {document.body.style.cursor=null}*/, undefined, undefined, false, false)});
+			whrb.addEventListener("mousedown", e => {DragAndDrop.add(e, `#${whrb.id}`, `#${win.id}`, undefined, moveUpAndClean, undefined, dragResizeWHRB, undefined, undefined, undefined, false, false)});
 		}
 
 		window.addEventListener("mouseup", e => {DragAndDrop.drop(e, `#${win.id}`)});


### PR DESCRIPTION
Before this change, custom resize cursors appeared only when the mouse was pressed/dragging the window border. Now they appear too by just hovering (passing over) those areas.